### PR TITLE
Add getErrors method.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@toreda/fate",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"description": "",
 	"public": true,
 	"main": "./dist/index.js",

--- a/src/fate.ts
+++ b/src/fate.ts
@@ -1,14 +1,14 @@
+import {
+	StrongBoolean,
+	StrongString,
+	StrongUInt,
+	makeBoolean,
+	makeString,
+	makeUInt
+} from '@toreda/strong-types';
 import {jsonType} from '@toreda/types';
 import {FateObject} from './fate/object';
 import {FateOptions} from './fate/options';
-import {
-	StrongUInt,
-	makeUInt,
-	StrongString,
-	makeString,
-	StrongBoolean,
-	makeBoolean
-} from '@toreda/strong-types';
 
 export class Fate<T = unknown> {
 	/** Data containing a valid & complete object of type T when used by this object. */
@@ -253,6 +253,22 @@ export class Fate<T = unknown> {
 		}
 
 		return JSON.stringify(state, this.serializeErrors);
+	}
+
+	public getErrors(fullTrace?: false): string[];
+	public getErrors(fullTrace: true): Error[];
+	public getErrors(fullTrace?: boolean): Error[] | string[] {
+		if (fullTrace) {
+			return this.errorLog;
+		}
+
+		return this.errorLog.map((v) => {
+			return v.message;
+		});
+	}
+
+	public getMessages(): string[] {
+		return this.messageLog;
 	}
 
 	private serializeErrors(_key: string, errors: unknown): unknown {

--- a/tests/fate.spec.ts
+++ b/tests/fate.spec.ts
@@ -23,7 +23,7 @@ describe('Fate', () => {
 	describe('Construction', () => {
 		it('should not throw with no args', () => {
 			expect(() => {
-				const custom = new Fate();
+				new Fate();
 			}).not.toThrow();
 		});
 
@@ -374,6 +374,45 @@ describe('Fate', () => {
 			expect(instance.status()).toBe(0);
 			instance.reset();
 			expect(instance.status()).toBe(0);
+		});
+	});
+
+	describe(`Getting Errors`, () => {
+		beforeEach(() => {
+			instance.error('Error 1');
+			instance.error('Error 2');
+			instance.error('Error 3');
+			instance.error('Error 4');
+		});
+
+		it(`should return array of errors if fullTrace is true`, () => {
+			const errors = instance.getErrors(true);
+
+			expect(Array.isArray(errors)).toBe(true);
+
+			errors.forEach((err) => {
+				expect(err).toBeInstanceOf(Error);
+			});
+		});
+
+		it(`should return array of strings if fullTrace is false`, () => {
+			const errors = instance.getErrors(false);
+
+			expect(Array.isArray(errors)).toBe(true);
+
+			errors.forEach((err) => {
+				expect(typeof err).toBe('string');
+			});
+		});
+
+		it(`should return array of strings if fullTrace is not provided`, () => {
+			const errors = instance.getErrors();
+
+			expect(Array.isArray(errors)).toBe(true);
+
+			errors.forEach((err) => {
+				expect(typeof err).toBe('string');
+			});
 		});
 	});
 


### PR DESCRIPTION
Calling it returns errors as strings. Calling it with true returns full
errors objects.